### PR TITLE
feat: migrate from Bun to npm for package management and CI

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,32 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...90"
+  status:
+    project:
+      default:
+        # Target coverage compared against the base. "auto" = Codecov infers target
+        target: auto
+        # Allow small fluctuations without failing
+        threshold: 1%
+        base: auto
+    patch:
+      default:
+        # Require minimum coverage on changed lines (patch)
+        target: 60%
+        threshold: 1%
+
+ignore:
+  - "dist/**"
+  - "coverage/**"
+  - "**/*.d.ts"
+  - "node_modules/**"
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+


### PR DESCRIPTION
## Overview\nMigrate the project from Bun to npm and stabilize CI. Include Codecov configuration and security workflow adjustments.\n\n## Changes\n- Replace Bun scripts with npm across package.json and docs\n- Update CI: npm install with clean install, Rollup native skip, Codecov v4 upload\n- Security workflow: remove dependency-review job; license allowlist includes Python-2.0; switch audits to npm\n- Add codecov.yml configuration\n\n## Verification\n- npm run test:run / test:coverage pass locally\n- CI runs complete with coverage upload\n\n## Notes\n- Requires CODECOV_TOKEN secret in repository settings