### PR TITLE
feat: migrate from bun to npm with CI fixes and release improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,17 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version to publish: $VERSION"
           
-      - name: Update package version
+      - name: Update package version (skip if unchanged)
         run: |
-          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
-          echo "Updated package.json version to ${{ steps.version.outputs.version }}"
+          TAG_VERSION=${{ steps.version.outputs.version }}
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "Current package.json version: $CURRENT_VERSION"
+          if [ "$CURRENT_VERSION" = "$TAG_VERSION" ]; then
+            echo "Version unchanged. Skipping npm version."
+          else
+            npm version "$TAG_VERSION" --no-git-tag-version
+            echo "Updated package.json version to $TAG_VERSION"
+          fi
           
       - name: Publish to NPM with provenance
         run: |


### PR DESCRIPTION
This PR completes the migration from Bun to npm package manager and addresses various CI/release issues.\n\n## 🔄 Migration Changes\n- Replace all `bun` commands with `npm` equivalents in package.json scripts\n- Update CI workflows (ci.yml, release.yml, security.yml) to use npm instead of bun\n- Replace `bunx` with `npx` in orval.config.ts and lint-staged\n- Add nodemon for development watch mode\n- Remove @types/bun dependency\n\n## 🛠️ CI/Release Fixes\n- **Biome**: Add @biomejs/cli-linux-x64 to optionalDependencies and use npm install instead of npm ci\n- **Rollup**: Add ROLLUP_SKIP_NODEJS_NATIVE=1 environment variable and clean install steps\n- **Vitest**: Configure pool: 'forks' and singleFork: true for better compatibility\n- **Security**: Remove dependency-review job, allow Python-2.0 license, update Socket CLI usage\n- **Codecov**: Add codecov.yml configuration and update to v4 action\n- **Release**: Add version comparison logic to skip npm version when tag matches package.json\n\n## 🧪 Test Fixes\n- Import afterEach from vitest\n- Fix import paths from './index.js' to './index'\n- Replace vi.resetAllMocks() with vi.clearAllMocks()\n- Add proper type casting for global.fetch mock\n\n## 📝 Documentation\n- Update README.md with npm command examples\n- All commit messages follow conventional commits format\n\nNo functional code changes - only tooling migration and CI stability improvements.