### PR TITLE
fix: resolve GitHub workflow permissions for release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - 'v*.*.*-*'  # v1.0.0-alpha.1, v1.0.0-beta.1 etc.
 
 permissions:
-  contents: read
+  contents: write # for creating GitHub releases
   id-token: write # for npm provenance
 
 jobs:


### PR DESCRIPTION
## 🔧 Fix GitHub Workflow Permissions Issue

### Problem
The release workflow was failing with the error:
`Resource not accessible by integration - https://docs.github.com/rest/releases/releases#update-a-release`

### Root Cause
The `permissions` section in `.github/workflows/release.yml` only had `contents: read` permission, but creating GitHub releases requires `contents: write` permission.

### Solution
- ✅ Updated `permissions.contents` from `read` to `write` in `release.yml`
- ✅ Added explanatory comment for clarity

### Changes
- `.github/workflows/release.yml`: Updated permissions to allow GitHub release creation

### Testing
The next release workflow run should complete successfully without permission errors.

### Related
This is part of the bun-to-npm migration effort and ensures the release process works correctly with the new setup.