### PR TITLE
fix: remove postinstall script to prevent orval dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,8 @@
     "voicevox:start": "docker-compose up -d voicevox",
     "voicevox:stop": "docker-compose down",
     "voicevox:logs": "docker-compose logs -f voicevox",
-    "prepublishOnly": "npm run test:run && npm run build:dual",
-    "prepare": "husky",
-    "postinstall": "npm run generate"
+    "prepublishOnly": "npm run generate && npm run test:run && npm run build:dual",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",


### PR DESCRIPTION
## Problem
The npm package @suzumiyaaoba/voicevox-client fails to install because it runs `npm run generate` on postinstall, but the `orval` CLI is only available in devDependencies, causing 'orval: not found' error in production environments.

## Solution
- **Remove postinstall script** that runs `npm run generate`
- **Move generate step to prepublishOnly** to ensure generated files are included in published package
- Keep `orval` as devDependency to minimize package size

## Changes
- Removed: `"postinstall": "npm run generate"`
- Updated: `"prepublishOnly": "npm run generate && npm run test:run && npm run build:dual"`

## Benefits
✅ Fixes installation errors for package users  
✅ Maintains optimal package size  
✅ Ensures generated files are always included in published package  

Fixes the issue where users installing the package encounter:
```
sh: 1: orval: not found
```