### PR TITLE
fix: resolve date display issue in GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,20 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version to publish: $VERSION"
           
+      - name: Get current UTC timestamp
+        id: timestamp
+        run: |
+          UTC_TIME=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          echo "utc_time=$UTC_TIME" >> $GITHUB_OUTPUT
+          echo "Current UTC time: $UTC_TIME"
+          
+      - name: Get previous tag for changelog
+        id: previous_tag
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          echo "previous_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+          echo "Previous tag: $PREV_TAG"
+          
       - name: Update package version (skip if unchanged)
         run: |
           TAG_VERSION=${{ steps.version.outputs.version }}
@@ -102,7 +116,7 @@ jobs:
             
             - **Package**: [@suzumiyaaoba/voicevox-client](https://www.npmjs.com/package/@suzumiyaaoba/voicevox-client)
             - **Version**: ${{ steps.version.outputs.version }}
-            - **Published**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+            - **Published**: ${{ steps.timestamp.outputs.utc_time }}
             - **Node.js Support**: >= 18.0.0
             
             ### 🔒 Security & Verification
@@ -125,7 +139,7 @@ jobs:
             
             ---
             
-            **Full Changelog**: https://github.com/${{ github.repository }}/compare/$(git describe --tags --abbrev=0 HEAD^)...v${{ steps.version.outputs.version }}
+            **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.previous_tag.outputs.previous_tag }}...v${{ steps.version.outputs.version }}
           draft: false
           prerelease: ${{ contains(steps.version.outputs.version, 'alpha') || contains(steps.version.outputs.version, 'beta') || contains(steps.version.outputs.version, 'rc') }}
           generate_release_notes: true


### PR DESCRIPTION
## Problem
Release notes in GitHub releases show raw shell commands instead of actual timestamps:
- Shows: `$(date -u +"%Y-%m-%d %H:%M:%S UTC")`
- Should show: `2025-09-27 06:21:41 UTC`

This happens because the shell command is not executed in the GitHub Actions environment when generating release notes.

## Solution
Replace raw shell commands with proper GitHub Actions step outputs:

### Changes Made:
1. **Added timestamp step**: Get current UTC time using GitHub Actions
2. **Added previous tag step**: Get previous tag for changelog generation  
3. **Updated release notes template**:
   - `$(date -u +"%Y-%m-%d %H:%M:%S UTC")` → `${{ steps.timestamp.outputs.utc_time }}`
   - `$(git describe --tags --abbrev=0 HEAD^)` → `${{ steps.previous_tag.outputs.previous_tag }}`

## Benefits
✅ **Correct date display**: Shows actual UTC timestamp instead of shell command  
✅ **Proper changelog links**: Full Changelog URLs work correctly  
✅ **GitHub Actions compatible**: Uses proper GitHub Actions syntax  
✅ **No breaking changes**: Only affects release note formatting  

## Before/After
**Before**: `Published: $(date -u +"%Y-%m-%d %H:%M:%S UTC")`  
**After**: `Published: 2025-09-27 15:21:41 UTC`

This fix ensures release notes display proper timestamps for better user experience.