### PR TITLE
Replace Orval with openapi-fetch and openapi-typescript

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm run test:run
         
       - name: Run linter
-        run: npm run check
+        run: npm run check -- --verbose
         
       - name: Build package
         run: npm run build:dual

--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,7 @@
     "lineWidth": 100
   },
   "linter": {
-    "enabled": false,
+    "enabled": true,
     "rules": {
       "recommended": true
     }

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env tsx
 
-import { execSync } from 'child_process';
-import { readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 const API_SCHEMA_PATH = './api-schema/openapi.json';
 const TYPES_OUTPUT_PATH = './src/types.ts';
@@ -21,7 +20,7 @@ try {
   console.log('✨ Post-processing generated files...');
 
   // Read the generated types file
-  let typesContent = readFileSync(TYPES_OUTPUT_PATH, 'utf-8');
+  const typesContent = readFileSync(TYPES_OUTPUT_PATH, 'utf-8');
 
   // No need to add additional exports as openapi-typescript already exports everything
   // Write the types file as is


### PR DESCRIPTION
## Summary

This PR migrates the project from Orval to openapi-fetch and openapi-typescript for better maintainability and modern OpenAPI tooling.

## Changes

- ✅ Remove Orval dependency and configuration
- ✅ Add openapi-fetch and openapi-typescript dependencies  
- ✅ Create new type generation script using openapi-typescript
- ✅ Update package.json scripts and keywords
- ✅ Replace generated client with openapi-fetch based implementation
- ✅ Update tests to work with new client API
- ✅ Fix TypeScript typecheck errors
- ✅ Fix linting issues and enable Biome linter
- ✅ Maintain same functionality with modern OpenAPI tooling

## Benefits

- **Modern toolchain**: openapi-fetch and openapi-typescript are more lightweight and maintainable
- **Type safety**: Maintains existing type safety while providing more flexible API client
- **Better performance**: More efficient client implementation
- **Active maintenance**: openapi-fetch and openapi-typescript are actively maintained
- **Improved linting**: Enhanced code quality with Biome linter

## Testing

- ✅ All tests pass
- ✅ Build succeeds
- ✅ Type generation works correctly
- ✅ Client functionality preserved
- ✅ Linting issues resolved

## Version

Bumped to v0.2.0 to reflect the significant architectural change.