### PR TITLE
Fix CI linting issues with generated types

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,8 @@
       "**/*.js",
       "!**/dist",
       "!**/node_modules",
-      "!**/coverage"
+      "!**/coverage",
+      "!src/types.ts"
     ]
   },
   "formatter": {

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -41,6 +41,16 @@ export default client;
   // Write the client file
   writeFileSync(CLIENT_OUTPUT_PATH, clientContent);
 
+  // Format the generated files
+  console.log('🎨 Formatting generated files...');
+  try {
+    execSync('npx @biomejs/biome format --write src/types.ts src/client.ts', {
+      stdio: 'inherit',
+    });
+  } catch (formatError) {
+    console.warn('⚠️  Formatting failed, but continuing...', formatError);
+  }
+
   console.log('✅ Successfully generated OpenAPI types and client!');
 } catch (error) {
   console.error('❌ Error generating types and client:', error);


### PR DESCRIPTION
## Summary

This PR fixes CI linting issues that were causing the release workflow to fail due to formatting conflicts with auto-generated type files.

## Changes

- ✅ Exclude generated types.ts from Biome linting using correct syntax
- ✅ Add formatting step to type generation script
- ✅ Prevent formatting conflicts with auto-generated files

## Problem

The release workflow was failing at the linter step because:
- The auto-generated  file (3000+ lines) had formatting issues
- Biome formatter couldn't handle the large generated file properly
- This caused the CI to fail with exit code 1

## Solution

1. **Exclude generated files**: Added  to Biome's file includes to skip linting
2. **Improve generation script**: Added formatting step after type generation
3. **Prevent conflicts**: Generated files are now excluded from strict formatting rules

## Benefits

- ✅ CI pipeline will now pass successfully
- ✅ Release workflow will complete without errors
- ✅ Generated files are properly handled
- ✅ Manual code still gets proper linting and formatting

## Testing

- ✅ Local linting passes
- ✅ Generated files are excluded from checks
- ✅ Type generation script includes formatting step

This fix ensures that the release workflow can complete successfully while maintaining code quality for manually written files.