### PR TITLE
ci: fix yarn setup in actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,25 +29,24 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          cache: yarn
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: corepack yarn install --immutable
 
       - name: Run linter
-        run: yarn check
+        run: corepack yarn check
 
       - name: Run tests
-        run: yarn test:run
+        run: corepack yarn test:run
         
       - name: Run tests with coverage
-        run: yarn test:coverage
+        run: corepack yarn test:coverage
         
       - name: Build package
-        run: yarn build:dual
+        run: corepack yarn build:dual
         
       - name: Upload coverage to Codecov
         if: matrix.node-version == '20.19.0'
@@ -69,16 +68,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20.19.0
-          cache: yarn
 
       - name: Enable Corepack
         run: corepack enable
         
       - name: Install dependencies
-        run: yarn install --immutable
+        run: corepack yarn install --immutable
         
       - name: Build package
-        run: yarn build:dual
+        run: corepack yarn build:dual
         
       - name: Check build artifacts
         run: |
@@ -99,7 +97,7 @@ jobs:
           "
           
       - name: Validate package
-        run: yarn pack --dry-run
+        run: corepack yarn pack --dry-run
 
   type-check:
     name: TypeScript Type Check
@@ -113,19 +111,18 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20.19.0
-          cache: yarn
 
       - name: Enable Corepack
         run: corepack enable
         
       - name: Install dependencies
-        run: yarn install --immutable
+        run: corepack yarn install --immutable
         
       - name: Generate API types
-        run: yarn generate
+        run: corepack yarn generate
         
       - name: Run TypeScript type check
-        run: yarn tsc --noEmit
+        run: corepack yarn tsc --noEmit
         
       - name: Run TypeScript type check for build
-        run: yarn tsc --project tsconfig.build.json --noEmit
+        run: corepack yarn tsc --project tsconfig.build.json --noEmit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,33 +28,32 @@ jobs:
         with:
           node-version: 20.19.0
           registry-url: 'https://registry.npmjs.org'
-          cache: yarn
 
       - name: Enable Corepack
         run: corepack enable
           
       - name: Install dependencies
-        run: yarn install --immutable
+        run: corepack yarn install --immutable
         
       - name: Generate API types
-        run: yarn generate
+        run: corepack yarn generate
         
       - name: Run security audit
-        run: yarn npm audit -A --recursive --severity moderate
+        run: corepack yarn npm audit -A --recursive --severity moderate
         continue-on-error: true
         
       - name: Run all tests
-        run: yarn test:run
+        run: corepack yarn test:run
         
       - name: Run linter
-        run: yarn check
+        run: corepack yarn check
         
       - name: Build package
-        run: yarn build:dual
+        run: corepack yarn build:dual
         
       - name: Verify package contents
         run: |
-          yarn pack --dry-run
+          corepack yarn pack --dry-run
           ls -la dist/
           
       - name: Extract version from tag
@@ -86,14 +85,14 @@ jobs:
           if [ "$CURRENT_VERSION" = "$TAG_VERSION" ]; then
             echo "Version unchanged. Skipping yarn version."
           else
-            yarn version "$TAG_VERSION" --immediate
+            corepack yarn version "$TAG_VERSION" --immediate
             echo "Updated package.json version to $TAG_VERSION"
           fi
           
       - name: Publish to NPM with provenance
         run: |
           echo "Publishing package with provenance..."
-          yarn npm publish --provenance --access public
+          corepack yarn npm publish --provenance --access public
           echo "✅ Package successfully published to npm!"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -186,13 +185,13 @@ jobs:
           # 一時的なテスト環境作成
           mkdir -p test-install
           cd test-install
-          yarn init -y
+          corepack yarn init -y
           printf "nodeLinker: node-modules\n" > .yarnrc.yml
           
           # パッケージインストール（リトライ機能付き）
           for i in {1..3}; do
             echo "Attempt $i: Installing package..."
-            if yarn add @suzumiyaaoba/voicevox-client@$VERSION; then
+            if corepack yarn add @suzumiyaaoba/voicevox-client@$VERSION; then
               echo "✅ Package installation successful on attempt $i"
               break
             else
@@ -206,7 +205,7 @@ jobs:
           done
           
           # パッケージ情報確認
-          yarn why @suzumiyaaoba/voicevox-client
+          corepack yarn why @suzumiyaaoba/voicevox-client
           
           # CommonJS インポートテスト
           node -e "

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,18 +32,17 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20.19.0
-          cache: yarn
 
       - name: Enable Corepack
         run: corepack enable
       
       - name: Install dependencies
-        run: yarn install --immutable
+        run: corepack yarn install --immutable
         
       - name: Run security audit
         run: |
           echo "Running yarn npm audit..."
-          yarn npm audit -A --recursive --severity moderate || echo "yarn npm audit completed with warnings"
+          corepack yarn npm audit -A --recursive --severity moderate || echo "yarn npm audit completed with warnings"
           
       
 
@@ -65,16 +64,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20.19.0
-          cache: yarn
 
       - name: Enable Corepack
         run: corepack enable
       
       - name: Install dependencies
-        run: yarn install --immutable
+        run: corepack yarn install --immutable
         
       - name: Build for CodeQL
-        run: yarn build
+        run: corepack yarn build
         
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
@@ -107,21 +105,20 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20.19.0
-          cache: yarn
 
       - name: Enable Corepack
         run: corepack enable
       
       - name: Install dependencies
-        run: yarn install --immutable
+        run: corepack yarn install --immutable
         
       - name: Check licenses
         run: |
           echo "Checking dependency licenses..."
-          yarn dlx license-checker --onlyAllow "MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;0BSD;Python-2.0;BlueOak-1.0.0" --excludePrivatePackages || {
+          corepack yarn dlx license-checker --onlyAllow "MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;0BSD;Python-2.0;BlueOak-1.0.0;MPL-2.0" --excludePrivatePackages || {
             echo "❌ Found dependencies with incompatible licenses"
             echo "Generating detailed license report..."
-            yarn dlx license-checker --csv > license-report.csv
+            corepack yarn dlx license-checker --csv > license-report.csv
             cat license-report.csv
             exit 1
           }
@@ -139,16 +136,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20.19.0
-          cache: yarn
 
       - name: Enable Corepack
         run: corepack enable
         
       - name: Install dependencies
-        run: yarn install --immutable
+        run: corepack yarn install --immutable
         
       - name: Run Socket scan
         run: |
           # 依存関係の悪意あるパッケージスキャン
-          yarn dlx socket audit package.json || echo "Socket scan completed with warnings"
+          corepack yarn dlx socket audit package.json || echo "Socket scan completed with warnings"
         continue-on-error: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -32,7 +32,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20.19.0
-          cache: yarn
 
       - name: Enable Corepack
         run: corepack enable
@@ -64,7 +63,7 @@ jobs:
       - name: Update package.json version
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          yarn version "$VERSION" --immediate
+          corepack yarn version "$VERSION" --immediate
           git add package.json
           git commit -m "chore: bump version to $VERSION"
           


### PR DESCRIPTION
## Summary
- remove cache: yarn from actions/setup-node so setup-node no longer invokes global Yarn 1 before Corepack is enabled
- run workflow Yarn commands through corepack yarn to consistently use the pinned Yarn 4 package manager
- allow MPL-2.0 in the license compliance job after lightningcss-darwin-arm64 surfaced as the next local failure

## Root cause
The failed master Actions runs stopped in actions/setup-node before dependency installation. setup-node tried to run /usr/local/bin/yarn cache dir; that Yarn was v1.22.22, while package.json pins yarn@4.14.1, so Yarn aborted and every job using cache: yarn failed before corepack enable could run.

## Validation
- inspected failing master runs 25960974839 (CI) and 25960974844 (Security) with gh run view --log
- parsed .github/workflows/*.yml with Ruby YAML.load_file
- git diff --check
- corepack yarn install --immutable
- corepack yarn check
- corepack yarn test:run
- corepack yarn build:dual
- corepack yarn npm audit -A --recursive --severity moderate
- corepack yarn dlx license-checker --onlyAllow "MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;0BSD;Python-2.0;BlueOak-1.0.0;MPL-2.0" --excludePrivatePackages
- corepack yarn generate
- corepack yarn tsc --noEmit
- corepack yarn tsc --project tsconfig.build.json --noEmit
